### PR TITLE
Fix for defd3f439f336a5c90532ce133b132a467ebbff5

### DIFF
--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -264,7 +264,7 @@ module BacklogsPlugin
                                   url_for_prefix_in_hooks + bulk_update_issues_path(:ids => issues, :issue => {:release_id => s}, :back_url => context[:back]),
                                   :method => :post,
                                   :selected => (issue && s == issue.release),
-                                  :disabled => !context[:can][:update])+
+                                  :disabled => !context[:can][:edit])+
               '</li>'
           end
           snippet += '<li>' +
@@ -272,7 +272,7 @@ module BacklogsPlugin
                                   url_for_prefix_in_hooks + bulk_update_issues_path(:ids => issues, :issue => {:release_id => 'none'}, :back_url => context[:back]),
                                   :method => :post,
                                   :selected => (issue && issue.release.nil?),
-                                  :disabled => !context[:can][:update])+
+                                  :disabled => !context[:can][:edit])+
             '</li>'
           snippet += '
               </ul>


### PR DESCRIPTION
In Redmine commit defd3f439f336a5c90532ce133b132a467ebbff5, Jean-Philippe Lang said:
Removed :update key and use :edit instead.
git-svn-id: http://svn.redmine.org/redmine/trunk@13953 e93f8b46-1217-0410-a6f0-8f06a7374b81