### PR TITLE
Optimize backlogs page using collection caching

### DIFF
--- a/app/views/rb_master_backlogs/_backlog.html.erb
+++ b/app/views/rb_master_backlogs/_backlog.html.erb
@@ -13,6 +13,6 @@
     <%- end %>
   </div>
   <ul id="stories-for-<%= backlog[:sprint] ? backlog[:sprint].id : 'product-backlog' %>" class="stories">
-    <%= render :partial => "rb_stories/story", :collection => backlog[:stories] %>
+    <%= render :partial => "rb_stories/story", :collection => backlog[:stories], cached: true %>
   </ul>
 </div>

--- a/app/views/rb_stories/_story.html.erb
+++ b/app/views/rb_stories/_story.html.erb
@@ -1,3 +1,4 @@
+<% cache story do %>
 <li class="model <%= story.backlogs_issue_type %> fff-wrapper <%= mark_if_closed(story) %> tracker<%= story ? story.tracker_id : '' %>" id="<%= story_html_id_or_empty(story) %>" story ="story_<%=story.id%>">
   <%- story_color = nil %>
   <%- front_color = nil %>
@@ -121,3 +122,4 @@
  </div>
   <div class="clearfix"></div>
 </li>
+<% end %>


### PR DESCRIPTION
We use collection caching and fragment caching to optimize our rendering time by ~96%